### PR TITLE
7 console log list

### DIFF
--- a/LogReader.Console/Contracts/Services/IConsoleService.cs
+++ b/LogReader.Console/Contracts/Services/IConsoleService.cs
@@ -2,5 +2,5 @@
 
 public interface IConsoleService
 {
-    void Run(string[] args);
+    Task RunAsync(string[] args);
 }

--- a/LogReader.Console/Program.cs
+++ b/LogReader.Console/Program.cs
@@ -8,11 +8,11 @@ namespace LogReader.Console;
 
 public class Program
 {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
         var serviceProvider = ConfigureServices();
         var consoleService = serviceProvider.GetRequiredService<IConsoleService>();
-        consoleService.Run(args);
+        await consoleService.RunAsync(args);
     }
     
     public static IServiceProvider ConfigureServices()

--- a/LogReader.Console/Properties/launchSettings.json
+++ b/LogReader.Console/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "LogReader.Console": {
-      "commandName": "Project",
-      "commandLineArgs": "..\\..\\..\\Program.cs"
+      "commandName": "Project"
     }
   }
 }

--- a/LogReader.Console/Properties/launchSettings.json
+++ b/LogReader.Console/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "LogReader.Console": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "..\\..\\..\\..\\LogReader.Tests.MSTest\\Assets\\logs_input.txt"
     }
   }
 }

--- a/LogReader.Console/Services/ConsoleService.cs
+++ b/LogReader.Console/Services/ConsoleService.cs
@@ -3,6 +3,8 @@ using LogReader.Core.Contracts.Services;
 
 namespace LogReader.Console.Services;
 
+using System;
+
 public class ConsoleService : IConsoleService
 {
     private readonly ILogFileService _logFileService;
@@ -12,20 +14,56 @@ public class ConsoleService : IConsoleService
         _logFileService = logFileService;
     }
 
-    public void Run(string[] args)
+    public async Task RunAsync(string[] args)
     {
         if (args is not [{ } fileName])
         {
-            System.Console.WriteLine("Error: The file name cannot be empty. Please enter a file name.");
+            Console.WriteLine("Error: The file name cannot be empty. Please enter a file name.");
+            return;
+        }
+        
+        var logFile = await _logFileService.TryReadAsync(fileName);
+        if (logFile is null)
+        {
+            Console.WriteLine($"Error: File \"{fileName}\" does not exist or cannot be accessed. Please check the file path and try again.");
             return;
         }
 
-        //if (!_logFileService.TryRead(fileName, out var fileContent))
-        //{
-        //    System.Console.WriteLine($"Error: File \"{fileName}\" does not exist or cannot be accessed. Please check the file path and try again.");
-        //    return;
-        //}
+        Console.CancelKeyPress += (_, _) => {
+            ClearLine(false);
+            Console.WriteLine("Exit triggered by Ctrl+C.");
+            Environment.Exit(0);
+        };
 
-        //System.Console.WriteLine(fileContent);
+        for (var i = 0; i < logFile.Records.Count; i++)
+        {
+            Console.WriteLine(logFile.Records[i].Text);
+            Console.WriteLine(new string('-', 80));
+
+            if (i < logFile.Records.Count - 1)
+            {
+                Console.Write("Press any key to display the next log record, or Ctrl+C to exit.");
+                var input = Console.ReadLine();
+                if (input == null) // Ctrl+C
+                {
+                    return;
+                }
+            }
+
+            ClearLine(true);
+        }
+
+        Console.WriteLine("No more log records to display.");
+
+        static void ClearLine(bool oneLineBack)
+        {
+            if (Console.IsOutputRedirected)
+            {
+                return;
+            }
+            Console.SetCursorPosition(0, Console.CursorTop - (oneLineBack ? 1 : 0));
+            Console.Write(new string(' ', Console.WindowWidth));
+            Console.SetCursorPosition(0, Console.CursorTop);
+        }
     }
 }

--- a/LogReader.Console/Services/ConsoleService.cs
+++ b/LogReader.Console/Services/ConsoleService.cs
@@ -30,7 +30,7 @@ public class ConsoleService : IConsoleService
         }
 
         Console.CancelKeyPress += (_, _) => {
-            ClearLine(false);
+            ClearLine();
             Console.WriteLine("Exit triggered by Ctrl+C.");
             Environment.Exit(0);
         };
@@ -43,27 +43,36 @@ public class ConsoleService : IConsoleService
             if (i < logFile.Records.Count - 1)
             {
                 Console.Write("Press any key to display the next log record, or Ctrl+C to exit.");
-                var input = Console.ReadLine();
-                if (input == null) // Ctrl+C
-                {
-                    return;
-                }
+                ReadKey();
             }
 
-            ClearLine(true);
+            ClearLine();
         }
 
         Console.WriteLine("No more log records to display.");
+    }
 
-        static void ClearLine(bool oneLineBack)
+    private static void ClearLine()
+    {
+        if (Console.IsOutputRedirected)
         {
-            if (Console.IsOutputRedirected)
-            {
-                return;
-            }
-            Console.SetCursorPosition(0, Console.CursorTop - (oneLineBack ? 1 : 0));
-            Console.Write(new string(' ', Console.WindowWidth));
-            Console.SetCursorPosition(0, Console.CursorTop);
+            return;
+        }
+        Console.SetCursorPosition(0, Console.CursorTop);
+        Console.Write(new string(' ', Console.WindowWidth));
+        Console.SetCursorPosition(0, Console.CursorTop);
+    }
+
+    private static void ReadKey()
+    {
+        if (Console.IsOutputRedirected)
+        {
+            Console.ReadLine();
+            Console.ReadLine();
+        }
+        else
+        {
+            Console.ReadKey();
         }
     }
 }

--- a/LogReader.Console/Services/ConsoleService.cs
+++ b/LogReader.Console/Services/ConsoleService.cs
@@ -20,12 +20,12 @@ public class ConsoleService : IConsoleService
             return;
         }
 
-        if (!_logFileService.TryRead(fileName, out var fileContent))
-        {
-            System.Console.WriteLine($"Error: File \"{fileName}\" does not exist or cannot be accessed. Please check the file path and try again.");
-            return;
-        }
+        //if (!_logFileService.TryRead(fileName, out var fileContent))
+        //{
+        //    System.Console.WriteLine($"Error: File \"{fileName}\" does not exist or cannot be accessed. Please check the file path and try again.");
+        //    return;
+        //}
 
-        System.Console.WriteLine(fileContent);
+        //System.Console.WriteLine(fileContent);
     }
 }

--- a/LogReader.Core/Contracts/Services/ILogFileService.cs
+++ b/LogReader.Core/Contracts/Services/ILogFileService.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using LogReader.Core.Models;
+﻿using LogReader.Core.Models;
 
 namespace LogReader.Core.Contracts.Services;
 
@@ -12,7 +11,6 @@ public interface ILogFileService
     /// Attempts to read the content of the specified log file.
     /// </summary>
     /// <param name="fileName">The name or path of the file to read.</param>
-    /// <param name="logFile">When this method returns, contains the data of the log file if the file was read successfully, or null if the file could not be accessed.</param>
-    /// <returns><c>true</c> if the file was read successfully; otherwise, <c>false</c>.</returns>
-    bool TryRead(string fileName, [NotNullWhen(true)] out LogFileModel? logFile);
+    /// <returns>The data of the log file if the file was read successfully; otherwise, null.</returns>
+    Task<LogFileModel?> TryReadAsync(string fileName);
 }

--- a/LogReader.Core/Contracts/Services/ILogFileService.cs
+++ b/LogReader.Core/Contracts/Services/ILogFileService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using LogReader.Core.Models;
 
 namespace LogReader.Core.Contracts.Services;
 
@@ -11,7 +12,7 @@ public interface ILogFileService
     /// Attempts to read the content of the specified log file.
     /// </summary>
     /// <param name="fileName">The name or path of the file to read.</param>
-    /// <param name="content">When this method returns, contains the content of the file if the file was read successfully, or null if the file could not be accessed.</param>
+    /// <param name="logFile">When this method returns, contains the data of the log file if the file was read successfully, or null if the file could not be accessed.</param>
     /// <returns><c>true</c> if the file was read successfully; otherwise, <c>false</c>.</returns>
-    bool TryRead(string fileName, [NotNullWhen(true)] out string? content);
+    bool TryRead(string fileName, [NotNullWhen(true)] out LogFileModel? logFile);
 }

--- a/LogReader.Core/Models/LogFileModel.cs
+++ b/LogReader.Core/Models/LogFileModel.cs
@@ -1,0 +1,3 @@
+﻿namespace LogReader.Core.Models;
+
+public record LogFileModel(IReadOnlyList<LogRecordModel> Records);

--- a/LogReader.Core/Models/LogRecordModel.cs
+++ b/LogReader.Core/Models/LogRecordModel.cs
@@ -1,0 +1,3 @@
+﻿namespace LogReader.Core.Models;
+
+public record LogRecordModel(string Text);

--- a/LogReader.Core/Services/LogFileService.cs
+++ b/LogReader.Core/Services/LogFileService.cs
@@ -1,4 +1,5 @@
 ﻿using LogReader.Core.Contracts.Services;
+using LogReader.Core.Models;
 
 namespace LogReader.Core.Services;
 
@@ -8,15 +9,17 @@ namespace LogReader.Core.Services;
 public class LogFileService : ILogFileService
 {
     /// <inheritdoc/>
-    public bool TryRead(string fileName, out string? content)
+    public bool TryRead(string fileName, out LogFileModel? logFile)
     {
-        if (!File.Exists(fileName))
-        {
-            content = null;
-            return false;
-        }
+        //if (!File.Exists(fileName))
+        //{
+        //    content = null;
+        //    return false;
+        //}
         
-        content = File.ReadAllText(fileName);
-        return true;
+        //content = File.ReadAllText(fileName);
+        //return true;
+        logFile = null;
+        return false;
     }
 }

--- a/LogReader.Desktop/ViewModels/ShellViewModel.cs
+++ b/LogReader.Desktop/ViewModels/ShellViewModel.cs
@@ -34,7 +34,7 @@ public partial class ShellViewModel : ObservableObject
             AllowMultiple = false
         });
         var fileName = files[0].TryGetLocalPath()!;
-        if (!_logFileService.TryRead(fileName, out var logs))
+        if (!_logFileService.TryRead(fileName, out _ /*logs*/))
         {
             var msg = MessageBoxManager.GetMessageBoxStandard(
                 "Open Text File",
@@ -45,7 +45,8 @@ public partial class ShellViewModel : ObservableObject
             return;
         }
 
-        LogViewModel = new(logs);
+        // TODO: set correct logs
+        LogViewModel = new(""/*logs*/);
     }
 
     [RelayCommand]

--- a/LogReader.Desktop/ViewModels/ShellViewModel.cs
+++ b/LogReader.Desktop/ViewModels/ShellViewModel.cs
@@ -34,16 +34,16 @@ public partial class ShellViewModel : ObservableObject
             AllowMultiple = false
         });
         var fileName = files[0].TryGetLocalPath()!;
-        if (!_logFileService.TryRead(fileName, out _ /*logs*/))
-        {
-            var msg = MessageBoxManager.GetMessageBoxStandard(
-                "Open Text File",
-                $"{fileName}\r\nFile not found.\r\nCheck the file name and try again.",
-                ButtonEnum.Ok,
-                Icon.Warning);
-            await msg.ShowWindowDialogAsync(_desktopService.MainWindow);
-            return;
-        }
+        //if (!_logFileService.TryRead(fileName, out _ /*logs*/))
+        //{
+        //    var msg = MessageBoxManager.GetMessageBoxStandard(
+        //        "Open Text File",
+        //        $"{fileName}\r\nFile not found.\r\nCheck the file name and try again.",
+        //        ButtonEnum.Ok,
+        //        Icon.Warning);
+        //    await msg.ShowWindowDialogAsync(_desktopService.MainWindow);
+        //    return;
+        //}
 
         // TODO: set correct logs
         LogViewModel = new(""/*logs*/);

--- a/LogReader.Tests.MSTest/Assets/expected_output_console.txt
+++ b/LogReader.Tests.MSTest/Assets/expected_output_console.txt
@@ -1,0 +1,22 @@
+2010-01-01 simple log record
+--------------------------------------------------------------------------------
+Press any key to display the next log record, or Ctrl+C to exit.2010-01-05 2010-01-06 multiple dates
+--------------------------------------------------------------------------------
+Press any key to display the next log record, or Ctrl+C to exit.2010-01-02 log record with empty lines and spaces at the end
+
+   
+--------------------------------------------------------------------------------
+Press any key to display the next log record, or Ctrl+C to exit.2010-01-03 log
+record
+with
+multiple
+lines
+2010-01-OO false record
+ 2010-01-07 shifted date
+--------------------------------------------------------------------------------
+Press any key to display the next log record, or Ctrl+C to exit.2010-01-04 multiline log record
+with spaces and empty lines at the end
+
+  
+--------------------------------------------------------------------------------
+No more log records to display.

--- a/LogReader.Tests.MSTest/Assets/expected_output_records.txt
+++ b/LogReader.Tests.MSTest/Assets/expected_output_records.txt
@@ -1,0 +1,20 @@
+2010-01-01 simple log record
+---
+2010-01-05 2010-01-06 multiple dates
+---
+2010-01-02 log record with empty lines and spaces at the end
+
+   
+---
+2010-01-03 log
+record
+with
+multiple
+lines
+2010-01-OO false record
+ 2010-01-07 shifted date
+---
+2010-01-04 multiline log record
+with spaces and empty lines at the end
+
+  

--- a/LogReader.Tests.MSTest/Assets/logs_input.txt
+++ b/LogReader.Tests.MSTest/Assets/logs_input.txt
@@ -1,0 +1,18 @@
+confusing file start
+without records
+2010-01-01 simple log record
+2010-01-05 2010-01-06 multiple dates
+2010-01-02 log record with empty lines and spaces at the end
+
+   
+2010-01-03 log
+record
+with
+multiple
+lines
+2010-01-OO false record
+ 2010-01-07 shifted date
+2010-01-04 multiline log record
+with spaces and empty lines at the end
+
+  

--- a/LogReader.Tests.MSTest/LogReader.Tests.MSTest.csproj
+++ b/LogReader.Tests.MSTest/LogReader.Tests.MSTest.csproj
@@ -24,4 +24,16 @@
     <ProjectReference Include="..\LogReader.Core\LogReader.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Assets\expected_output_console.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\expected_output_records.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\logs_input.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/LogReader.Tests.MSTest/ProgramTests.cs
+++ b/LogReader.Tests.MSTest/ProgramTests.cs
@@ -6,29 +6,69 @@ namespace LogReader.Tests.MSTest;
 public class ProgramTests
 {
     [TestMethod]
-    public void Main_FileExists_ShowsContent()
+    public async Task Main_FileExists_ShowsContent()
     {
         //Arrange
         var tempFileName = Path.GetTempFileName();
-        const string fileContent = "Test content";
-        File.WriteAllText(tempFileName, fileContent);
+        var logRecords = new[]
+        {
+            """
+            confusing file start
+            without records
+            """,
+            "2010-01-01 simple log record",
+            "2010-01-05 2010-01-06 multiple dates",
+            """
+            2010-01-02 log record with empty lines and spaces at the end
+
+               
+            """,
+            """
+            2010-01-03 log
+            record
+            with
+            multiple
+            lines
+            2010-01-OO false record
+             2010-01-07 shifted date
+            """,
+            """
+            2010-01-04 multiline log record
+            with spaces and empty lines at the end
+
+              
+            """
+        };
+
+        var separatorLine = new string('-', 80);
+        var pressAnyKeyMessage = "Press any key to display the next log record, or Ctrl+C to exit.";
+        var expectedOutput = string.Join(
+            Environment.NewLine + separatorLine + Environment.NewLine + pressAnyKeyMessage,
+            logRecords.Skip(1)
+        );
+        expectedOutput += $"{Environment.NewLine}{separatorLine}{Environment.NewLine}No more log records to display.{Environment.NewLine}";
+
+        var fileContent = string.Join(Environment.NewLine, logRecords);
+        await File.WriteAllTextAsync(tempFileName, fileContent);
 
         var stringWriter = new StringWriter();
         System.Console.SetOut(stringWriter);
-
+        var input = string.Join("", Enumerable.Repeat(Environment.NewLine, logRecords.Length - 1));
+        System.Console.SetIn(new StringReader(input));
+        
         //Act
-        Program.Main(new[] { tempFileName });
+        await Program.Main(new[] { tempFileName });
 
         //Assert
         var output = stringWriter.ToString();
-        Assert.AreEqual(fileContent + Environment.NewLine, output);
+        Assert.AreEqual(expectedOutput, output);
 
         // Cleanup
         File.Delete(tempFileName);
     }
 
     [TestMethod]
-    public void Main_FileDoesNotExist_ShowsError()
+    public async Task Main_FileDoesNotExist_ShowsError()
     {
         //Arrange
         var nonExistentFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -37,7 +77,7 @@ public class ProgramTests
         System.Console.SetOut(stringWriter);
 
         //Act
-        Program.Main(new[] { nonExistentFile });
+        await Program.Main(new[] { nonExistentFile });
 
         //Assert
         var output = stringWriter.ToString();
@@ -47,14 +87,14 @@ public class ProgramTests
     }
 
     [TestMethod]
-    public void Main_NoParams_ShowsError()
+    public async Task Main_NoParams_ShowsError()
     {
         //Arrange
         var stringWriter = new StringWriter();
         System.Console.SetOut(stringWriter);
 
         //Act
-        Program.Main(Array.Empty<string>());
+        await Program.Main(Array.Empty<string>());
 
         //Assert
         var output = stringWriter.ToString();

--- a/LogReader.Tests.MSTest/Services/LogFileServiceTests.cs
+++ b/LogReader.Tests.MSTest/Services/LogFileServiceTests.cs
@@ -14,21 +14,21 @@ public class LogFileServiceTests
     }
 
     [TestMethod]
-    public void TryRead_FileExistsButEmpty_ReturnsTrueAndNoRecords()
+    public async Task TryRead_FileExistsButEmpty_ReturnsFileModelAndNoRecords()
     {
         // Arrange
         var tempFileName = Path.GetTempFileName();
-        var fileContent = "";
-        File.WriteAllText(tempFileName, fileContent);
+        const string fileContent = "";
+        await File.WriteAllTextAsync(tempFileName, fileContent);
 
         // Act
-        var result = _logFileService.TryRead(tempFileName, out var logFile);
+        var logFile = await _logFileService.TryReadAsync(tempFileName);
 
         // Assert
-        Assert.IsTrue(result);
+        Assert.IsNotNull(logFile);
 
         var expectedRecords = Array.Empty<string>();
-        var actualRecords = logFile!.Records.Select(r => r.Text).ToList();
+        var actualRecords = logFile.Records.Select(r => r.Text).ToList();
         CollectionAssert.AreEqual(expectedRecords, actualRecords);
 
         // Cleanup
@@ -36,11 +36,12 @@ public class LogFileServiceTests
     }
 
     [TestMethod]
-    public void TryRead_FileExistsWithRandomText_ReturnsTrueAndNoRecords()
+    public async Task TryRead_FileExistsWithRandomText_ReturnsFileModelAndNoRecords()
     {
         // Arrange
         var tempFileName = Path.GetTempFileName();
         var fileContent =
+            // ReSharper disable once StringLiteralTypo
             """
             Lorem ipsum dolor sit amet, consectetur adipiscing elit,
             sed do eiusmod tempor incididunt ut labore et dolore magna
@@ -51,16 +52,16 @@ public class LogFileServiceTests
             occaecat cupidatat non proident, sunt in culpa qui officia
             deserunt mollit anim id est laborum.
             """;
-        File.WriteAllText(tempFileName, fileContent);
+        await File.WriteAllTextAsync(tempFileName, fileContent);
 
         // Act
-        var result = _logFileService.TryRead(tempFileName, out var logFile);
+        var logFile = await _logFileService.TryReadAsync(tempFileName);
 
         // Assert
-        Assert.IsTrue(result);
+        Assert.IsNotNull(logFile);
 
         var expectedRecords = Array.Empty<string>();
-        var actualRecords = logFile!.Records.Select(r => r.Text).ToList();
+        var actualRecords = logFile.Records.Select(r => r.Text).ToList();
         CollectionAssert.AreEqual(expectedRecords, actualRecords);
 
         // Cleanup
@@ -68,7 +69,7 @@ public class LogFileServiceTests
     }
 
     [TestMethod]
-    public void TryRead_FileExistsWithRecords_ReturnsTrueAndRecords()
+    public async Task TryRead_FileExistsWithRecords_ReturnsFileModelAndRecords()
     {
         // Arrange
         var tempFileName = Path.GetTempFileName();
@@ -102,16 +103,16 @@ public class LogFileServiceTests
             """
         };
         var fileContent = string.Join(Environment.NewLine, logRecords);
-        File.WriteAllText(tempFileName, fileContent);
+        await File.WriteAllTextAsync(tempFileName, fileContent);
 
         // Act
-        var result = _logFileService.TryRead(tempFileName, out var logFile);
+        var logFile = await _logFileService.TryReadAsync(tempFileName);
 
         // Assert
-        Assert.IsTrue(result);
+        Assert.IsNotNull(logFile);
 
         var expectedRecords = logRecords[1..]; // Without the first false lines
-        var actualRecords = logFile!.Records.Select(r => r.Text).ToList();
+        var actualRecords = logFile.Records.Select(r => r.Text).ToList();
         CollectionAssert.AreEqual(expectedRecords, actualRecords);
 
         // Cleanup
@@ -119,16 +120,15 @@ public class LogFileServiceTests
     }
 
     [TestMethod]
-    public void TryRead_FileDoesNotExist_ReturnsFalse()
+    public async Task TryRead_FileDoesNotExist_ReturnsNull()
     {
         // Arrange
         var nonExistentFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
         // Act
-        var result = _logFileService.TryRead(nonExistentFile, out var content);
+        var logFile = await _logFileService.TryReadAsync(nonExistentFile);
 
         // Assert
-        Assert.IsFalse(result);
-        Assert.IsNull(content);
+        Assert.IsNull(logFile);
     }
 }

--- a/LogReader.Tests.MSTest/Services/LogFileServiceTests.cs
+++ b/LogReader.Tests.MSTest/Services/LogFileServiceTests.cs
@@ -14,18 +14,105 @@ public class LogFileServiceTests
     }
 
     [TestMethod]
-    public void TryRead_FileExists_ReturnsTrueAndSetsContent()
+    public void TryRead_FileExistsButEmpty_ReturnsTrueAndNoRecords()
     {
         // Arrange
         var tempFileName = Path.GetTempFileName();
-        File.WriteAllText(tempFileName, "Test content");
+        var fileContent = "";
+        File.WriteAllText(tempFileName, fileContent);
 
         // Act
-        var result = _logFileService.TryRead(tempFileName, out var content);
+        var result = _logFileService.TryRead(tempFileName, out var logFile);
 
         // Assert
         Assert.IsTrue(result);
-        Assert.AreEqual("Test content", content);
+
+        var expectedRecords = Array.Empty<string>();
+        var actualRecords = logFile!.Records.Select(r => r.Text).ToList();
+        CollectionAssert.AreEqual(expectedRecords, actualRecords);
+
+        // Cleanup
+        File.Delete(tempFileName);
+    }
+
+    [TestMethod]
+    public void TryRead_FileExistsWithRandomText_ReturnsTrueAndNoRecords()
+    {
+        // Arrange
+        var tempFileName = Path.GetTempFileName();
+        var fileContent =
+            """
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+            sed do eiusmod tempor incididunt ut labore et dolore magna
+            aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+            ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            Duis aute irure dolor in reprehenderit in voluptate velit
+            esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+            occaecat cupidatat non proident, sunt in culpa qui officia
+            deserunt mollit anim id est laborum.
+            """;
+        File.WriteAllText(tempFileName, fileContent);
+
+        // Act
+        var result = _logFileService.TryRead(tempFileName, out var logFile);
+
+        // Assert
+        Assert.IsTrue(result);
+
+        var expectedRecords = Array.Empty<string>();
+        var actualRecords = logFile!.Records.Select(r => r.Text).ToList();
+        CollectionAssert.AreEqual(expectedRecords, actualRecords);
+
+        // Cleanup
+        File.Delete(tempFileName);
+    }
+
+    [TestMethod]
+    public void TryRead_FileExistsWithRecords_ReturnsTrueAndRecords()
+    {
+        // Arrange
+        var tempFileName = Path.GetTempFileName();
+        var logRecords = new[]
+        {
+            """
+            confusing file start
+            without records
+            """,
+            "2010-01-01 simple log record",
+            "2010-01-05 2010-01-06 multiple dates",
+            """
+            2010-01-02 log record with empty lines and spaces at the end
+
+               
+            """,
+            """
+            2010-01-03 log
+            record
+            with
+            multiple
+            lines
+            2010-01-OO false record
+             2010-01-07 shifted date
+            """,
+            """
+            2010-01-04 multiline log record
+            with spaces and empty lines at the end
+
+              
+            """
+        };
+        var fileContent = string.Join(Environment.NewLine, logRecords);
+        File.WriteAllText(tempFileName, fileContent);
+
+        // Act
+        var result = _logFileService.TryRead(tempFileName, out var logFile);
+
+        // Assert
+        Assert.IsTrue(result);
+
+        var expectedRecords = logRecords[1..]; // Without the first false lines
+        var actualRecords = logFile!.Records.Select(r => r.Text).ToList();
+        CollectionAssert.AreEqual(expectedRecords, actualRecords);
 
         // Cleanup
         File.Delete(tempFileName);


### PR DESCRIPTION
Implemented the basic functionality of a log reader app in the console API. The application is now able to read and parse log files, separating the logs by the dates on which the logs begin. Here's an example:

```
2010-01-01 log record 1
2010-01-02 multiline
log
record 2
2010-01-03 log record 3
```
#7 