### PR TITLE
Fixed the Bug with Log Records Shuffling on 'Reload File' Action

### DIFF
--- a/LogReader.Desktop/ViewModels/FileViewModel.cs
+++ b/LogReader.Desktop/ViewModels/FileViewModel.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections;
+using System.IO;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LogReader.Core.Models;
+using LogReader.Core.Services;
 
 namespace LogReader.Desktop.ViewModels;
 
@@ -32,12 +34,9 @@ public partial class FileViewModel : ObservableObject
     /// </summary>
     public FileViewModel()
     {
-        var records = Enumerable.Range(0, 10)
-            .Select(i => new Record(DateTimeOffset.Now, $"Details #{i}"))
-            .ToList();
-
-        _file = new(null!, null!, null!); // Using 'null!' to satisfy the constructor requirement.
-        _file.Records.AddRange(records);
+        var fileReader = new FileReader(new LogParser(), new FileAppendMonitorFactory());
+        var fileInfo = new FileInfo(@".\LogReader.Desktop\Assets\random_log_file.txt");
+        File = fileReader.Load(fileInfo);
     }
 
     /// <summary>
@@ -60,9 +59,9 @@ public partial class FileViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void SelectionsChanged(IList items)
+    private void SelectionsChanged(IList selectedRecords)
     {
-        var messages = items
+        var messages = selectedRecords
             .Cast<Record>()
             .Select(r => r.Message);
 

--- a/LogReader.Desktop/ViewModels/ShellViewModel.cs
+++ b/LogReader.Desktop/ViewModels/ShellViewModel.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls.ApplicationLifetimes;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using LogReader.Core.Services;
 using LogReader.Desktop.Contracts.Services;
 
 namespace LogReader.Desktop.ViewModels;
@@ -42,11 +43,12 @@ public partial class ShellViewModel : ObservableObject
         _dialogService = null!;
         _desktopService = null!;
         _directoryViewModelFactory = null!;
+        var fileReader = new FileReader(new LogParser(), new FileAppendMonitorFactory());
         Directories = new()
         {
-            new(new("LogReader.Desktop"), null!),
-            new(new("LogReader.Core"), null!),
-            new(new("LogReader.Tests"), null!)
+            new(new(@"LogReader.Desktop\Assets\"), fileReader),
+            new(new("LogReader.Core"), fileReader),
+            new(new("LogReader.Tests"), fileReader)
         };
     }
 

--- a/LogReader.Desktop/Views/FileView.axaml
+++ b/LogReader.Desktop/Views/FileView.axaml
@@ -36,8 +36,8 @@
                  IsReadOnly="True"
                  SelectionMode="Extended">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Timestamp" Binding="{Binding Timestamp, StringFormat=G}"/>
-                <DataGridTextColumn Header="Message" Binding="{Binding Message, Mode=OneTime,
+                <DataGridTextColumn Header="Timestamp" Binding="{Binding Timestamp, Mode=OneWay, StringFormat=G}"/>
+                <DataGridTextColumn Header="Message" Binding="{Binding Message, Mode=OneWay,
                                     Converter={x:Static helpers:StringTruncationConverter.Right},
                                     ConverterParameter={StaticResource MaxHeaderLength}}"/>
             </DataGrid.Columns>
@@ -65,7 +65,7 @@
 
         <!-- Detailed view of the selected log -->
         <TextBox Name="Detail"
-                 Text="{Binding Details}"
+                 Text="{Binding Details, Mode=OneWay}"
                  Grid.Column="2"
                  AcceptsReturn="True"
                  IsReadOnly="True"


### PR DESCRIPTION
This update addresses the issue where log records were getting shuffled each time the "Reload File" button was pressed. The root cause of this issue was identified in the binding mode, which has now been corrected to ensure consistent ordering of log records upon reloading.

Closes #37 